### PR TITLE
fix: deleting cache after failed sign in with user cache

### DIFF
--- a/client/src/screens/login.js
+++ b/client/src/screens/login.js
@@ -60,6 +60,7 @@ const Login = (props) => {
         console.log("Cookies found");
         try {
           const user = await LoginWithActiveSession();
+          console.log("User aaaa: ", user);
           if (user) {
             var userData = await user.data;
             userData = decodeURIComponent(JSON.stringify(userData.user));

--- a/client/src/services/authenticationUtil.js
+++ b/client/src/services/authenticationUtil.js
@@ -33,6 +33,7 @@ async function getUserInfoWithGoogle(token) {
 }
 
 export async function logout() {
+  console.log("Logging out and deleting user cookies");
   await AsyncStorage.removeItem("cookies");
   await AsyncStorage.removeItem("user");
   // remove the cookie header from axios
@@ -48,12 +49,20 @@ export async function CASLogout() {
  * @returns {} - The user data if found; otherwise, null.
  */
 export async function LoginWithActiveSession() {
-  const response = await AuthApi.get("/login", { withCredentials: true });
-  
-  // Clear session if session is invalid / unauthorized user
-  if (response.status == StatusCodes.UNAUTHORIZED) {
-    logout();
+  let response = null;
+  try {
+    response = await AuthApi.get("/login", { withCredentials: true });
+  } catch (err) {
+    // Clear session if session is invalid / unauthorized user
+    console.error(
+      "Error logging in with stored cookies. Logging out",
+      err.response.status
+    );
+    if (err.response.status == StatusCodes.UNAUTHORIZED) {
+      logout();
+    }
+  } finally {
+    // eslint-disable-next-line no-unsafe-finally
+    return response?.status === 200 ? response : null;
   }
-
-  return response.status === 200 ? response : null;
 }


### PR DESCRIPTION
## Summary of PR
Fixing the deleting of cached sessions after failed sign in with the cache

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I have tested on the iOS simulator
- [x] I have made corresponding changes to the documentation

## Todos & Follow ups
