### PR TITLE
fix: await user insertion after logging in

### DIFF
--- a/client/src/screens/login.js
+++ b/client/src/screens/login.js
@@ -60,7 +60,6 @@ const Login = (props) => {
         console.log("Cookies found");
         try {
           const user = await LoginWithActiveSession();
-          console.log("User aaaa: ", user);
           if (user) {
             var userData = await user.data;
             userData = decodeURIComponent(JSON.stringify(userData.user));

--- a/server/src/controllers/authentication/casAuthController.js
+++ b/server/src/controllers/authentication/casAuthController.js
@@ -17,36 +17,38 @@ import { StatusCodes } from "http-status-codes";
  */
 
 export function CASLogin(req, res, next) {
-    console.log("Logging in with Yale CAS");
-    passport.authenticate("yalecas", (err, user) => {
-        if (err) {
-            return res
-                .status(StatusCodes.INTERNAL_SERVER_ERROR)
-                .json({ error: err.message });
-        }
+  console.log("Logging in with Yale CAS");
+  passport.authenticate("yalecas", async (err, user) => {
+    if (err) {
+      return res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ error: err.message });
+    }
+    
+    // Necessary to await actual user object and not use a promise
+    user = await user;
+    if (!user) {
+      return res
+        .status(StatusCodes.UNAUTHORIZED)
+        .json({ error: "Authentication failed" });
+    }
 
-        if (!user) {
-            return res
-                .status(StatusCodes.UNAUTHORIZED)
-                .json({ error: "Authentication failed" });
-        }
+    console.log("User Session: ", req.session);
 
-        console.log("User Session: ", req.session);
+    // Store user information in session upon successful authentication
+    // Adjust according to the user object structures
+    req.session.user = { user };
 
-        // Store user information in session upon successful authentication
-        // Adjust according to the user object structures
-        req.session.user = { user };
+    // You can now redirect the user or send a response as needed
+    // For example, redirect to a page with user data
+    const userData = JSON.stringify(user); // Convert user data to a string
 
-        // You can now redirect the user or send a response as needed
-        // For example, redirect to a page with user data
-        const userData = JSON.stringify(user); // Convert user data to a string
+    // Encode the user data
+    const encodedUserData = encodeURIComponent(userData);
 
-        // Encode the user data
-        const encodedUserData = encodeURIComponent(userData);
-
-        // Redirect with the user data
-        res.redirect(`${process.env.HOST_URL}/userdata?data=${encodedUserData}`);
-    })(req, res, next);
+    // Redirect with the user data
+    res.redirect(`${process.env.HOST_URL}/userdata?data=${encodedUserData}`);
+  })(req, res, next);
 }
 
 /**
@@ -55,52 +57,50 @@ export function CASLogin(req, res, next) {
  * @param {Express.Response} res - The response object from Express.
  */
 export function LoginWithActiveSession(req, res) {
-    console.log("Cookies: ", req.cookies);
-    if (req.cookies["connect.sid"]) {
-        const encodedSession = req.cookies["connect.sid"];
-        UserFromSession(encodedSession).then((user) => {
-            if (user) {
-                // Redirect to the user data page
-                const userData = JSON.stringify(user); // Convert user data to a string
-                const encodedUserData = encodeURIComponent(userData); // Encode the user data
-                res
-                    .status(StatusCodes.OK)
-                    .send({ user: encodedUserData });
-            } else {
-                res
-                    .status(StatusCodes.UNAUTHORIZED)
-                    .send({ error: "No user found. Sign in again" });
-            }
-        });
-    } else {
+  console.log("Cookies: ", req.cookies);
+  if (req.cookies["connect.sid"]) {
+    const encodedSession = req.cookies["connect.sid"];
+    UserFromSession(encodedSession).then((user) => {
+      if (user) {
+        // Redirect to the user data page
+        const userData = JSON.stringify(user); // Convert user data to a string
+        const encodedUserData = encodeURIComponent(userData); // Encode the user data
+        res.status(StatusCodes.OK).send({ user: encodedUserData });
+      } else {
         res
-            .status(StatusCodes.UNAUTHORIZED)
-            .send({ error: "No active session found. Sign in again" });
-    }
+          .status(StatusCodes.UNAUTHORIZED)
+          .send({ error: "No user found. Sign in again" });
+      }
+    });
+  } else {
+    res
+      .status(StatusCodes.UNAUTHORIZED)
+      .send({ error: "No active session found. Sign in again" });
+  }
 }
 
 export async function CASLogout(req, res) {
-    console.log("Logging out");
-    // place this in a try catch block to handle errors
-    try {
-        req.session.destroy((err) => {
-            if (err) {
-                console.error("Session destruction error:", err);
-                return res
-                    .status(StatusCodes.INTERNAL_SERVER_ERROR)
-                    .send({ error: "Could not log out, please try again." });
-            }
-            console.log("Session destroyed");
-            // Optional: Clear the cookie on client side
-            res.clearCookie("connect.sid"); // Adjust cookie name based on your setup
+  console.log("Logging out");
+  // place this in a try catch block to handle errors
+  try {
+    req.session.destroy((err) => {
+      if (err) {
+        console.error("Session destruction error:", err);
+        return res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .send({ error: "Could not log out, please try again." });
+      }
+      console.log("Session destroyed");
+      // Optional: Clear the cookie on client side
+      res.clearCookie("connect.sid"); // Adjust cookie name based on your setup
 
-            // Redirect to CAS logout URL or send a response
-            res.redirect(`${process.env.HOST_URL}/cas/logout`);
-        });
-    } catch (error) {
-        console.error("Error logging out:", error);
-        res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .send({ error: "Could not log out, please try again." });
-    }
+      // Redirect to CAS logout URL or send a response
+      res.redirect(`${process.env.HOST_URL}/cas/logout`);
+    });
+  } catch (error) {
+    console.error("Error logging out:", error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .send({ error: "Could not log out, please try again." });
+  }
 }

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -6,14 +6,14 @@ import mongoose from "mongoose";
 
 export async function createUser(user) {
   try {
-    const newUser = new User(user);
-    await newUser.save();
+    let newUser = new User(user);
+    newUser = await newUser.save();
     // User id is the primary key for user; default _id by MongoDB
     createPoints(newUser._id);
     createInitialAssets(newUser._id);
     return newUser;
   } catch (err) {
-    console.log("User already exists");
+    console.log("Error creating user: ", err);
     return null;
   }
 }


### PR DESCRIPTION
## Summary of PR
Before this change:
After logging in with CAS, the user data returned to the client would be empty. This is because the data returned to the client and also saved in the session in db is resolved to empty JSON.

After this change:
We await the user information returned from mongoDB after the user is created and returned to the server. Hence, the correct user info is returned to client at the point of login.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] I have tested on the iOS simulator
- [x] I have made corresponding changes to the documentation

## Todos & Follow ups
potential concern: Slight delay in times of network latency