### PR TITLE
fix: adding point and coin update to a single update function call

### DIFF
--- a/client/src/components/emotionVisualizer.js
+++ b/client/src/components/emotionVisualizer.js
@@ -21,7 +21,7 @@ const EmotionVisualizer = () => {
       const StringUserObject = JSON.parse(stringUser);
       const userObject = StringUserObject.slice(1, -1);
       const parsedUserObject = JSON.parse(userObject);
-      const college = parsedUserObject.college.toLowerCase();
+      const college = parsedUserObject.college?.toLowerCase();
 
       switch (college) {
         case "pierson":

--- a/client/src/services/PointsService.js
+++ b/client/src/services/PointsService.js
@@ -46,7 +46,7 @@ export async function updatePoints(newPoints) {
     }); // Post request to update points
 
     // Save new points in client's local storage
-    console.log("Harry's response from server", response.data.points);
+    console.log("Updated points from server", response.data.points);
     await AsyncStorage.setItem("points", JSON.stringify(response.data.points));
 
     return response.data.points;
@@ -60,8 +60,9 @@ export async function updatePoints(newPoints) {
 
 /**
  * @description Update the points of a category by a specified amount.
- * @param {String} category - The category to update. Eg. "Exercising", "Eating"...etc.
- * @param {Number} pointChange - The change in points.
+ * @param {String} category - The category to update with pointChange.point; Eg. "Exercising", "Eating"...etc.
+ * @param {JSON} pointChange - JSON object containing points change for category and coin change
+ * Eg. { "points": 5, "coins": 3 }
  * @returns {JSON} - The updated points if successful; otherwise, null.
  */
 export async function updatePointswithChange(category, pointChange) {
@@ -73,7 +74,8 @@ export async function updatePointswithChange(category, pointChange) {
     currentPoints = await getPointInfo();
   }
 
-  currentPoints[categoryPoints] += pointChange;
+  currentPoints[categoryPoints] += pointChange.points;
+  currentPoints.coins += pointChange.coins;
   return updatePoints(currentPoints);
 }
 

--- a/client/src/services/habitService.js
+++ b/client/src/services/habitService.js
@@ -35,9 +35,7 @@ export async function addHabit(newHabit) {
     console.log("category_name", newHabit.category_name);
     // Update points based on the new habit
     let { points, coins } = calculatePoints(newHabit);
-    console.log("Calculated COINS: ", coins);
-    updatePointswithChange(newHabit.category_name, points);
-    updatePointswithChange("coins", coins);
+    updatePointswithChange(newHabit.category_name, {"points": points, "coins": coins});
 
     return habit_response.data;
   } catch (err) {


### PR DESCRIPTION
## Summary of PR
Modified `UpdatePointsWithChange` to accept a JSON of points and coins, so that we make only one function call to server to update the points and coins. 

Whenever we update points, we update coins.
The 2 separate function calls were expensive and also causing race conditions.
Added a null checker to the college name finder from user attribute to avoid errors

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] I have tested on the iOS simulator
- [x] I have made corresponding changes to the documentation

## Todos & Follow ups
